### PR TITLE
Fix worktree merge UI update issue

### DIFF
--- a/client/src/components/MergeWorktreeDialog.tsx
+++ b/client/src/components/MergeWorktreeDialog.tsx
@@ -53,13 +53,16 @@ const MergeWorktreeDialog: React.FC<MergeWorktreeDialogProps> = ({
     setError(null);
 
     try {
-      await axios.post('/api/worktrees/merge', {
+      const response = await axios.post('/api/worktrees/merge', {
         sourceBranch,
         targetBranch,
         deleteAfterMerge,
         useRebase,
       });
       
+      console.log('[MergeDialog] Merge successful:', response.data);
+      
+      // Reset form and close dialog
       setSourceBranch('');
       setTargetBranch('');
       setDeleteAfterMerge(false);

--- a/client/src/pages/SessionManager.tsx
+++ b/client/src/pages/SessionManager.tsx
@@ -45,7 +45,9 @@ const SessionManager: React.FC = () => {
     setSocket(newSocket);
 
     newSocket.on('worktrees:updated', (updatedWorktrees: Worktree[]) => {
-      setWorktrees(updatedWorktrees);
+      console.log('[Client] Received worktrees:updated event with', updatedWorktrees.length, 'worktrees');
+      // Force React to detect the change by creating a new array
+      setWorktrees([...updatedWorktrees]);
     });
 
     newSocket.on('session:created', (session: Session) => {

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -7,6 +7,7 @@ import dotenv from 'dotenv';
 
 import { setupWebSocket } from './websocket/index.js';
 import { setupApiRoutes } from './api/index.js';
+import { SessionManager } from './services/sessionManager.js';
 
 dotenv.config();
 
@@ -23,11 +24,14 @@ const io = new Server(httpServer);
 // Middleware
 app.use(express.json());
 
-// API Routes (pass io for emitting events)
-setupApiRoutes(app, io);
+// Create shared SessionManager instance
+const sessionManager = new SessionManager();
 
-// WebSocket handling
-setupWebSocket(io);
+// API Routes (pass io and sessionManager)
+setupApiRoutes(app, io, sessionManager);
+
+// WebSocket handling (pass sessionManager)
+setupWebSocket(io, sessionManager);
 
 // Serve static files in production
 const publicPath = join(dirname(dirname(__dirname)), 'public');

--- a/server/src/websocket/index.ts
+++ b/server/src/websocket/index.ts
@@ -3,14 +3,15 @@ import { SessionManager } from '../services/sessionManager.js';
 import { WorktreeService } from '../services/worktreeService.js';
 import { Session, Worktree } from '../../../shared/types.js';
 
-export function setupWebSocket(io: Server) {
-  const sessionManager = new SessionManager();
+export function setupWebSocket(io: Server, sessionManager: SessionManager) {
   const worktreeService = new WorktreeService(process.env.WORK_DIR);
 
   // Update worktrees with session info
   const getWorktreesWithSessions = (): Worktree[] => {
     const worktrees = worktreeService.getWorktrees();
     const sessions = sessionManager.getAllSessions();
+    
+    console.log(`[WebSocket] Getting worktrees with sessions: ${worktrees.length} worktrees, ${sessions.length} sessions`);
     
     return worktrees.map(worktree => {
       const session = sessions.find(s => s.worktreePath === worktree.path);


### PR DESCRIPTION
- Share SessionManager instance between API and WebSocket handlers
- SessionManager was being instantiated separately causing data inconsistency
- API routes now receive the same SessionManager instance as WebSocket
- This ensures worktree updates include correct session information

Fixes the issue where UI doesn't update after merging worktrees

🤖 Generated with [Claude Code](https://claude.ai/code)

## Description
<!-- Describe your changes in detail -->

## Type of Change
<!-- Mark relevant items with an "x" -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring

## Testing
<!-- Describe the tests you ran -->

- [ ] Tested locally
- [ ] All tests pass
- [ ] Added new tests

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published